### PR TITLE
Added base error class for GatewayErrors

### DIFF
--- a/lib/cloud_payments/client/gateway_errors.rb
+++ b/lib/cloud_payments/client/gateway_errors.rb
@@ -1,5 +1,6 @@
 module CloudPayments
   class Client
+    class ReasonedGatewayError < StandardError; end
     module GatewayErrors; end
 
     REASON_CODES = {
@@ -29,7 +30,7 @@ module CloudPayments
 
     GATEWAY_ERRORS = REASON_CODES.inject({}) do |result, error|
       status, name = error
-      result[status] = GatewayErrors.const_set(name, Class.new(StandardError))
+      result[status] = GatewayErrors.const_set(name, Class.new(ReasonedGatewayError))
       result
     end
   end

--- a/spec/cloud_payments/namespaces/base_spec.rb
+++ b/spec/cloud_payments/namespaces/base_spec.rb
@@ -63,7 +63,13 @@ describe CloudPayments::Namespaces::Base do
 
       context 'config.raise_banking_errors = true' do
         before { CloudPayments.config.raise_banking_errors = true }
-        specify{ expect{ subject.request(:path, request_params) }.to raise_error(CloudPayments::Client::GatewayErrors::LostCard) }
+        specify do
+          begin
+            subject.request(:path, request_params)
+          rescue CloudPayments::Client::GatewayErrors::LostCard => err
+            expect(err).to be_a CloudPayments::Client::ReasonedGatewayError
+          end
+        end
       end
 
       context 'config.raise_banking_errors = false' do


### PR DESCRIPTION
It makes easier to rescue certain gateway errors by using base class `ReasonedGatewayError`.
