### PR TITLE
[WIP] Add API method subscriptions.find_all(account_id)

### DIFF
--- a/lib/cloud_payments/client/serializer/base.rb
+++ b/lib/cloud_payments/client/serializer/base.rb
@@ -20,7 +20,12 @@ module CloudPayments
 
         def convert_keys_from_api(attributes)
           attributes.each_with_object({}) do |(key, value), result|
-            value = convert_keys_from_api(value) if value.is_a?(Hash)
+            value = \
+              case value
+              when Hash  then convert_keys_from_api(value)
+              when Array then value.map { |item| convert_keys_from_api(item) }
+              else value
+              end
 
             key = key.to_s.gsub(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
             key.gsub!(/([a-z\d])([A-Z])/, '\1_\2')

--- a/lib/cloud_payments/namespaces/subscriptions.rb
+++ b/lib/cloud_payments/namespaces/subscriptions.rb
@@ -6,6 +6,11 @@ module CloudPayments
         Subscription.new(response[:model])
       end
 
+      def find_all(account_id)
+        response = request(:find, account_id: account_id)
+        Array(response[:model]).map { |item| Subscription.new(item) }
+      end
+
       def create(attributes)
         response = request(:create, attributes)
         Subscription.new(response[:model])

--- a/spec/cloud_payments/models/transaction_spec.rb
+++ b/spec/cloud_payments/models/transaction_spec.rb
@@ -205,7 +205,7 @@ describe CloudPayments::Transaction do
     subject{ CloudPayments::Transaction.new(default_attributes.merge(attributes)) }
 
     describe '#subscription' do
-      before{ stub_api_request('subscriptions/find/successful').perform }
+      before{ stub_api_request('subscriptions/get/successful').perform }
 
       context 'with subscription_id' do
         let(:attributes){ { subscription_id: 'sc_8cf8a9338fb' } }

--- a/spec/cloud_payments/namespaces/subscriptions_spec.rb
+++ b/spec/cloud_payments/namespaces/subscriptions_spec.rb
@@ -21,7 +21,7 @@ describe CloudPayments::Namespaces::Subscriptions do
     end
   end
 
-  describe '#find_all' do
+  describe '#find_all', :focus do
     context do
       before{ stub_api_request('subscriptions/find/successful').perform }
 

--- a/spec/cloud_payments/namespaces/subscriptions_spec.rb
+++ b/spec/cloud_payments/namespaces/subscriptions_spec.rb
@@ -5,12 +5,31 @@ describe CloudPayments::Namespaces::Subscriptions do
 
   describe '#find' do
     context do
-      before{ stub_api_request('subscriptions/find/successful').perform }
+      before{ stub_api_request('subscriptions/get/successful').perform }
 
       specify{ expect(subject.find('sc_8cf8a9338fb')).to be_instance_of(CloudPayments::Subscription) }
 
       context do
         let(:sub){ subject.find('sc_8cf8a9338fb') }
+
+        specify{ expect(sub.id).to eq('sc_8cf8a9338fb') }
+        specify{ expect(sub.account_id).to eq('user@example.com') }
+        specify{ expect(sub.description).to eq('Monthly subscription') }
+        specify{ expect(sub.started_at).to eq(DateTime.parse('2014-08-09T11:49:41')) }
+        specify{ expect(sub).to be_active }
+      end
+    end
+  end
+
+  describe '#find_all' do
+    context do
+      before{ stub_api_request('subscriptions/find/successful').perform }
+
+      specify{ expect(subject.find_all("user@example.com")).to be_instance_of(Array) }
+      specify{ expect(subject.find_all("user@example.com").first).to be_instance_of(CloudPayments::Subscription) }
+
+      context do
+        let(:sub){ subject.find_all("user@example.com").first }
 
         specify{ expect(sub.id).to eq('sc_8cf8a9338fb') }
         specify{ expect(sub.account_id).to eq('user@example.com') }

--- a/spec/cloud_payments/namespaces/subscriptions_spec.rb
+++ b/spec/cloud_payments/namespaces/subscriptions_spec.rb
@@ -21,7 +21,7 @@ describe CloudPayments::Namespaces::Subscriptions do
     end
   end
 
-  describe '#find_all', :focus do
+  describe '#find_all' do
     context do
       before{ stub_api_request('subscriptions/find/successful').perform }
 

--- a/spec/fixtures/apis/subscriptions/find/successful.yml
+++ b/spec/fixtures/apis/subscriptions/find/successful.yml
@@ -1,7 +1,7 @@
 ---
 :request:
   :url: '/subscriptions/find'
-  :body: '{"accountId":"user@example.com"}'
+  :body: '{"AccountId":"user@example.com"}'
 :response:
   :body: >
     {

--- a/spec/fixtures/apis/subscriptions/get/successful.yml
+++ b/spec/fixtures/apis/subscriptions/get/successful.yml
@@ -1,11 +1,11 @@
 ---
 :request:
-  :url: '/subscriptions/find'
-  :body: '{"accountId":"user@example.com"}'
+  :url: '/subscriptions/get'
+  :body: '{"Id":"sc_8cf8a9338fb"}'
 :response:
   :body: >
     {
-      "Model":[{
+      "Model":{
         "Id":"sc_8cf8a9338fb",
         "AccountId":"user@example.com",
         "Description":"Monthly subscription",
@@ -25,7 +25,7 @@
         "FailedTransactionsNumber":0,
         "LastTransactionDateIso":"2014-08-09T11:49:41",
         "NextTransactionDateIso":"2014-08-09T11:49:41"
-      }],
+      },
       "Success":true,
       "Message": null
     }


### PR DESCRIPTION
CP has implemented new method to return all subscriptions http://cloudpayments.ru/Docs/Api#find-recurrent, so we can add it to the client.
