### PR TITLE
CloudPayments payments/get and payments/find API calls

### DIFF
--- a/lib/cloud_payments/namespaces/payments.rb
+++ b/lib/cloud_payments/namespaces/payments.rb
@@ -27,6 +27,16 @@ module CloudPayments
         response = request(:post3ds, transaction_id: id, pa_res: pa_res)
         Transaction.new(response[:model])
       end
+
+      def get(id)
+        response = request(:get, transaction_id: id)
+        Transaction.new(response[:model])
+      end
+
+      def find(invoice_id)
+        response = request(:find, invoice_id: invoice_id)
+        Transaction.new(response[:model])
+      end
     end
   end
 end

--- a/lib/cloud_payments/version.rb
+++ b/lib/cloud_payments/version.rb
@@ -1,3 +1,3 @@
 module CloudPayments
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end

--- a/spec/cloud_payments/namespaces/payments_spec.rb
+++ b/spec/cloud_payments/namespaces/payments_spec.rb
@@ -114,7 +114,7 @@ describe CloudPayments::Namespaces::Payments do
         specify{ expect(subject.get(transaction_id).reason).to eq('InsufficientFunds') }
       end
 
-      context 'transaction is successfull' do
+      context 'transaction is successful' do
         before{ stub_api_request('payments/get/successful').perform }
         specify{ expect(subject.get(transaction_id)).to be_instance_of(CloudPayments::Transaction) }
         specify{ expect(subject.get(transaction_id)).not_to be_required_secure3d }
@@ -137,7 +137,7 @@ describe CloudPayments::Namespaces::Payments do
         specify{ expect{subject.get(transaction_id)}.to raise_error(CloudPayments::Client::GatewayErrors::InsufficientFunds) }
       end
 
-      context 'transaction is successfull' do
+      context 'transaction is successful' do
         before{ stub_api_request('payments/get/successful').perform }
         specify{ expect{subject.get(transaction_id)}.to_not raise_error }
         specify{ expect(subject.get(transaction_id)).to be_instance_of(CloudPayments::Transaction) }
@@ -170,7 +170,7 @@ describe CloudPayments::Namespaces::Payments do
         specify{ expect(subject.find(invoice_id).reason).to eq('InsufficientFunds') }
       end
 
-      context 'transaction is successfull' do
+      context 'transaction is successful' do
         before{ stub_api_request('payments/find/successful').perform }
         specify{ expect(subject.find(invoice_id)).to be_instance_of(CloudPayments::Transaction) }
         specify{ expect(subject.find(invoice_id)).not_to be_required_secure3d }
@@ -194,7 +194,7 @@ describe CloudPayments::Namespaces::Payments do
         specify{ expect{subject.find(invoice_id)}.to raise_error(CloudPayments::Client::GatewayErrors::InsufficientFunds) }
       end
 
-      context 'transaction is successfull' do
+      context 'transaction is successful' do
         before{ stub_api_request('payments/find/successful').perform }
         specify{ expect(subject.find(invoice_id)).to be_instance_of(CloudPayments::Transaction) }
         specify{ expect(subject.find(invoice_id)).not_to be_required_secure3d }

--- a/spec/cloud_payments/namespaces/payments_spec.rb
+++ b/spec/cloud_payments/namespaces/payments_spec.rb
@@ -93,4 +93,116 @@ describe CloudPayments::Namespaces::Payments do
       end
     end
   end
+
+  describe '#get' do
+    let(:transaction_id) { 12345 }
+
+    context 'config.raise_banking_errors = false' do
+      before { CloudPayments.config.raise_banking_errors = false }
+
+      context 'transaction not found' do
+        before{ stub_api_request('payments/get/failed_with_message').perform }
+        specify{ expect{subject.get(transaction_id)}.to raise_error(CloudPayments::Client::GatewayError, 'Not found') }
+      end
+
+      context 'transaction is failed' do
+        before{ stub_api_request('payments/get/failed').perform }
+        specify{ expect(subject.get(transaction_id)).to be_instance_of(CloudPayments::Transaction) }
+        specify{ expect(subject.get(transaction_id)).not_to be_required_secure3d }
+        specify{ expect(subject.get(transaction_id)).to be_declined }
+        specify{ expect(subject.get(transaction_id).id).to eq(transaction_id) }
+        specify{ expect(subject.get(transaction_id).reason).to eq('InsufficientFunds') }
+      end
+
+      context 'transaction is successfull' do
+        before{ stub_api_request('payments/get/successful').perform }
+        specify{ expect(subject.get(transaction_id)).to be_instance_of(CloudPayments::Transaction) }
+        specify{ expect(subject.get(transaction_id)).not_to be_required_secure3d }
+        specify{ expect(subject.get(transaction_id)).to be_completed }
+        specify{ expect(subject.get(transaction_id).id).to eq(transaction_id) }
+        specify{ expect(subject.get(transaction_id).reason).to eq('Approved') }
+      end
+    end
+
+    context 'config.raise_banking_errors = true' do
+      before { CloudPayments.config.raise_banking_errors = true}
+
+      context 'transaction not found' do
+        before{ stub_api_request('payments/get/failed_with_message').perform }
+        specify{ expect{subject.get(transaction_id)}.to raise_error(CloudPayments::Client::GatewayError, 'Not found') }
+      end
+
+      context 'transaction is failed' do
+        before{ stub_api_request('payments/get/failed').perform }
+        specify{ expect{subject.get(transaction_id)}.to raise_error(CloudPayments::Client::GatewayErrors::InsufficientFunds) }
+      end
+
+      context 'transaction is successfull' do
+        before{ stub_api_request('payments/get/successful').perform }
+        specify{ expect{subject.get(transaction_id)}.to_not raise_error }
+        specify{ expect(subject.get(transaction_id)).to be_instance_of(CloudPayments::Transaction) }
+        specify{ expect(subject.get(transaction_id)).not_to be_required_secure3d }
+        specify{ expect(subject.get(transaction_id)).to be_completed }
+        specify{ expect(subject.get(transaction_id).id).to eq(transaction_id) }
+        specify{ expect(subject.get(transaction_id).reason).to eq('Approved') }
+      end
+    end
+  end
+
+  describe '#find' do
+    let(:invoice_id) { '1234567' }
+
+    context 'config.raise_banking_errors = false' do
+      before { CloudPayments.config.raise_banking_errors = false }
+
+      context 'payment is not found' do
+        before{ stub_api_request('payments/find/failed_with_message').perform }
+        specify{ expect{subject.find(invoice_id)}.to raise_error(CloudPayments::Client::GatewayError, 'Not found') }
+      end
+
+      context 'payment is failed' do
+        before{ stub_api_request('payments/find/failed').perform }
+        specify{ expect(subject.find(invoice_id)).to be_instance_of(CloudPayments::Transaction) }
+        specify{ expect(subject.find(invoice_id)).not_to be_required_secure3d }
+        specify{ expect(subject.find(invoice_id)).to be_declined }
+        specify{ expect(subject.find(invoice_id).id).to eq(12345) }
+        specify{ expect(subject.find(invoice_id).invoice_id).to eq(invoice_id) }
+        specify{ expect(subject.find(invoice_id).reason).to eq('InsufficientFunds') }
+      end
+
+      context 'transaction is successfull' do
+        before{ stub_api_request('payments/find/successful').perform }
+        specify{ expect(subject.find(invoice_id)).to be_instance_of(CloudPayments::Transaction) }
+        specify{ expect(subject.find(invoice_id)).not_to be_required_secure3d }
+        specify{ expect(subject.find(invoice_id)).to be_completed }
+        specify{ expect(subject.find(invoice_id).id).to eq(12345) }
+        specify{ expect(subject.find(invoice_id).invoice_id).to eq(invoice_id) }
+        specify{ expect(subject.find(invoice_id).reason).to eq('Approved') }
+      end
+    end
+
+    context 'config.raise_banking_errors = true' do
+      before { CloudPayments.config.raise_banking_errors = true}
+
+      context 'payment is not found' do
+        before{ stub_api_request('payments/find/failed_with_message').perform }
+        specify{ expect{subject.find(invoice_id)}.to raise_error(CloudPayments::Client::GatewayError, 'Not found') }
+      end
+
+      context 'payment is failed' do
+        before{ stub_api_request('payments/find/failed').perform }
+        specify{ expect{subject.find(invoice_id)}.to raise_error(CloudPayments::Client::GatewayErrors::InsufficientFunds) }
+      end
+
+      context 'transaction is successfull' do
+        before{ stub_api_request('payments/find/successful').perform }
+        specify{ expect(subject.find(invoice_id)).to be_instance_of(CloudPayments::Transaction) }
+        specify{ expect(subject.find(invoice_id)).not_to be_required_secure3d }
+        specify{ expect(subject.find(invoice_id)).to be_completed }
+        specify{ expect(subject.find(invoice_id).id).to eq(12345) }
+        specify{ expect(subject.find(invoice_id).invoice_id).to eq(invoice_id) }
+        specify{ expect(subject.find(invoice_id).reason).to eq('Approved') }
+      end
+    end
+  end
 end

--- a/spec/fixtures/apis/payments/find/failed.yml
+++ b/spec/fixtures/apis/payments/find/failed.yml
@@ -1,0 +1,45 @@
+---
+:request:
+  :url: '/payments/find'
+  :body: '{"InvoiceId":"1234567"}'
+:response:
+  :body: >
+    {
+      "Model": {
+        "TransactionId": 12345,
+        "Amount": 10.0,
+        "Currency": "RUB",
+        "CurrencyCode": 0,
+        "PaymentAmount": 10.0,
+        "PaymentCurrency": "RUB",
+        "PaymentCurrencyCode": 0,
+        "InvoiceId": "1234567",
+        "AccountId": "user_x",
+        "Email": null,
+        "Description": "Payment for goods on example.com",
+        "JsonData": null,
+        "CreatedDate": "\/Date(1401718880000)\/",
+        "CreatedDateIso":"2014-08-09T11:49:41",
+        "TestMode": true,
+        "IpAddress": "195.91.194.13",
+        "IpCountry": "RU",
+        "IpCity": "Ufa",
+        "IpRegion": "Bashkortostan Republic",
+        "IpDistrict": "Volga Federal District",
+        "IpLatitude": 54.7355,
+        "IpLongitude": 55.991982,
+        "CardFirstSix": "411111",
+        "CardLastFour": "1111",
+        "CardType": "Visa",
+        "CardTypeCode": 0,
+        "IssuerBankCountry": "RU",
+        "Status": "Declined",
+        "StatusCode": 5,
+        "Reason": "InsufficientFunds",
+        "ReasonCode": 5051,
+        "CardHolderMessage": "Insufficient funds on account",
+        "Name": "CARDHOLDER NAME"
+      },
+      "Success": false,
+      "Message": null
+    }

--- a/spec/fixtures/apis/payments/find/failed_with_message.yml
+++ b/spec/fixtures/apis/payments/find/failed_with_message.yml
@@ -1,0 +1,6 @@
+---
+:request:
+  :url: '/payments/find'
+  :body: '{"InvoiceId":"1234567"}'
+:response:
+  :body: '{"Success":false,"Message":"Not found"}'

--- a/spec/fixtures/apis/payments/find/successful.yml
+++ b/spec/fixtures/apis/payments/find/successful.yml
@@ -1,0 +1,48 @@
+---
+:request:
+  :url: '/payments/find'
+  :body: '{"InvoiceId":"1234567"}'
+:response:
+  :body: >
+    {
+      "Model":{
+        "TransactionId":12345,
+        "Amount":10.0,
+        "Currency":"RUB",
+        "CurrencyCode":0,
+        "InvoiceId":"1234567",
+        "AccountId":"user_x",
+        "Email":null,
+        "Description":"Payment for goods on example.com",
+        "JsonData":null,
+        "CreatedDate":"\/Date(1401718880000)\/",
+        "CreatedDateIso":"2014-08-09T11:49:41",
+        "AuthDate":"\/Date(1401733880523)\/",
+        "AuthDateIso":"2014-08-09T11:49:42",
+        "ConfirmDate":"\/Date(1401733880523)\/",
+        "ConfirmDateIso":"2014-08-09T11:49:42",
+        "AuthCode":"123456",
+        "TestMode":true,
+        "IpAddress":"195.91.194.13",
+        "IpCountry":"RU",
+        "IpCity":"Ufa",
+        "IpRegion":"Bashkortostan Republic",
+        "IpDistrict":"Volga Federal District",
+        "IpLatitude":54.7355,
+        "IpLongitude":55.991982,
+        "CardFirstSix":"411111",
+        "CardLastFour":"1111",
+        "CardType":"Visa",
+        "CardTypeCode":0,
+        "IssuerBankCountry":"RU",
+        "Status":"Completed",
+        "StatusCode":3,
+        "Reason":"Approved",
+        "ReasonCode":0,
+        "CardHolderMessage":"Payment successful",
+        "Name":"CARDHOLDER NAME",
+        "Token":"a4e67841-abb0-42de-a364-d1d8f9f4b3c0"
+      },
+      "Success":true,
+      "Message": null
+    }

--- a/spec/fixtures/apis/payments/get/failed.yml
+++ b/spec/fixtures/apis/payments/get/failed.yml
@@ -1,0 +1,45 @@
+---
+:request:
+  :url: '/payments/get'
+  :body: '{"TransactionId":12345}'
+:response:
+  :body: >
+    {
+      "Model": {
+        "TransactionId": 12345,
+        "Amount": 10.0,
+        "Currency": "RUB",
+        "CurrencyCode": 0,
+        "PaymentAmount": 10.0,
+        "PaymentCurrency": "RUB",
+        "PaymentCurrencyCode": 0,
+        "InvoiceId": "1234567",
+        "AccountId": "user_x",
+        "Email": null,
+        "Description": "Payment for goods on example.com",
+        "JsonData": null,
+        "CreatedDate": "\/Date(1401718880000)\/",
+        "CreatedDateIso":"2014-08-09T11:49:41",
+        "TestMode": true,
+        "IpAddress": "195.91.194.13",
+        "IpCountry": "RU",
+        "IpCity": "Ufa",
+        "IpRegion": "Bashkortostan Republic",
+        "IpDistrict": "Volga Federal District",
+        "IpLatitude": 54.7355,
+        "IpLongitude": 55.991982,
+        "CardFirstSix": "411111",
+        "CardLastFour": "1111",
+        "CardType": "Visa",
+        "CardTypeCode": 0,
+        "IssuerBankCountry": "RU",
+        "Status": "Declined",
+        "StatusCode": 5,
+        "Reason": "InsufficientFunds",
+        "ReasonCode": 5051,
+        "CardHolderMessage": "Insufficient funds on account",
+        "Name": "CARDHOLDER NAME"
+      },
+      "Success": false,
+      "Message": null
+    }

--- a/spec/fixtures/apis/payments/get/failed_with_message.yml
+++ b/spec/fixtures/apis/payments/get/failed_with_message.yml
@@ -1,0 +1,6 @@
+---
+:request:
+  :url: '/payments/get'
+  :body: '{"TransactionId":12345}'
+:response:
+  :body: '{"Success":false,"Message":"Not found"}'

--- a/spec/fixtures/apis/payments/get/successful.yml
+++ b/spec/fixtures/apis/payments/get/successful.yml
@@ -1,0 +1,48 @@
+---
+:request:
+  :url: '/payments/get'
+  :body: '{"TransactionId":12345}'
+:response:
+  :body: >
+    {
+      "Model":{
+        "TransactionId":12345,
+        "Amount":10.0,
+        "Currency":"RUB",
+        "CurrencyCode":0,
+        "InvoiceId":"1234567",
+        "AccountId":"user_x",
+        "Email":null,
+        "Description":"Payment for goods on example.com",
+        "JsonData":null,
+        "CreatedDate":"\/Date(1401718880000)\/",
+        "CreatedDateIso":"2014-08-09T11:49:41",
+        "AuthDate":"\/Date(1401733880523)\/",
+        "AuthDateIso":"2014-08-09T11:49:42",
+        "ConfirmDate":"\/Date(1401733880523)\/",
+        "ConfirmDateIso":"2014-08-09T11:49:42",
+        "AuthCode":"123456",
+        "TestMode":true,
+        "IpAddress":"195.91.194.13",
+        "IpCountry":"RU",
+        "IpCity":"Ufa",
+        "IpRegion":"Bashkortostan Republic",
+        "IpDistrict":"Volga Federal District",
+        "IpLatitude":54.7355,
+        "IpLongitude":55.991982,
+        "CardFirstSix":"411111",
+        "CardLastFour":"1111",
+        "CardType":"Visa",
+        "CardTypeCode":0,
+        "IssuerBankCountry":"RU",
+        "Status":"Completed",
+        "StatusCode":3,
+        "Reason":"Approved",
+        "ReasonCode":0,
+        "CardHolderMessage":"Payment successful",
+        "Name":"CARDHOLDER NAME",
+        "Token":"a4e67841-abb0-42de-a364-d1d8f9f4b3c0"
+      },
+      "Success":true,
+      "Message": null
+    }


### PR DESCRIPTION
CloudPayments has implemented 2 methods to return info about transaction. There're they:
- [API payments/get](https://cloudpayments.ru/Docs/Api#get)
- [API payments/find](https://cloudpayments.ru/Docs/Api#find)

This is implementation for the client.