### PR TITLE
Add Issuer to transaction and callback payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ transaction = CloudPayments.client.payments.cards.charge(
 # :card_last_four=>"1111",
 # :card_type=>"Visa",
 # :card_type_code=>0,
+# :issuer=>"Sberbank of Russia",
 # :issuer_bank_country=>"RU",
 # :status=>"Completed",
 # :status_code=>3,

--- a/lib/cloud_payments/models/on_fail.rb
+++ b/lib/cloud_payments/models/on_fail.rb
@@ -23,6 +23,7 @@ module CloudPayments
     property :ip_city
     property :ip_region
     property :ip_district
+    property :issuer
     property :issuer_bank_country
     property :description
     property :metadata, from: :data, default: {}

--- a/lib/cloud_payments/models/on_pay.rb
+++ b/lib/cloud_payments/models/on_pay.rb
@@ -26,6 +26,7 @@ module CloudPayments
     property :card_type_code
     property :card_exp_date
     property :name
+    property :issuer
     property :issuer_bank_country
     property :status, required: true
     property :status_code

--- a/lib/cloud_payments/models/transaction.rb
+++ b/lib/cloud_payments/models/transaction.rb
@@ -36,6 +36,7 @@ module CloudPayments
     property :card_type_code
     property :card_exp_date
     property :name
+    property :issuer
     property :issuer_bank_country
     property :status, required: true
     property :status_code

--- a/spec/cloud_payments/models/transaction_spec.rb
+++ b/spec/cloud_payments/models/transaction_spec.rb
@@ -34,6 +34,7 @@ describe CloudPayments::Transaction do
       card_type: 'Visa',
       card_type_code: 0,
       card_exp_date: '10/17',
+      issuer: 'Sberbank of Russia',
       issuer_bank_country: 'RU',
       status: 'Completed',
       status_code: 3,
@@ -72,6 +73,7 @@ describe CloudPayments::Transaction do
     specify{ expect(subject.card_type).to eq('Visa') }
     specify{ expect(subject.card_type_code).to eq(0) }
     specify{ expect(subject.card_exp_date).to eq('10/17') }
+    specify{ expect(subject.issuer).to eq('Sberbank of Russia') }
     specify{ expect(subject.issuer_bank_country).to eq('RU') }
     specify{ expect(subject.reason).to eq('Approved') }
     specify{ expect(subject.reason_code).to eq(0) }
@@ -111,6 +113,7 @@ describe CloudPayments::Transaction do
     it_behaves_like :not_raise_without_attribute, :ip_longitude, :ip_lng
     it_behaves_like :not_raise_without_attribute, :card_type_code
     it_behaves_like :not_raise_without_attribute, :card_exp_date
+    it_behaves_like :not_raise_without_attribute, :issuer
     it_behaves_like :not_raise_without_attribute, :issuer_bank_country
     it_behaves_like :not_raise_without_attribute, :reason
     it_behaves_like :not_raise_without_attribute, :reason_code


### PR DESCRIPTION
Getting bank (Issuer) name from cloudpayments payload.

**Reason**

From page https://cloudpayments.ru/Docs/Notifications:

> Параметр | Формат | Применение | Описание
> -----------|----------|---------------|----------
> Issuer | String | Необязательный | Название банка-эмитента карты

From examples on page https://cloudpayments.ru/Docs/Api:

>    "CardTypeCode": 0,
>    "Issuer": "Sberbank of Russia",
>    "IssuerBankCountry": "RU",