### PR TITLE
Add "cancel" order API call

### DIFF
--- a/lib/cloud_payments/namespaces/orders.rb
+++ b/lib/cloud_payments/namespaces/orders.rb
@@ -6,6 +6,10 @@ module CloudPayments
         response = request(:create, attributes)
         Order.new(response[:model])
       end
+
+      def cancel(order_id)
+        request(:cancel, id: order_id)[:success]
+      end
     end
   end
 end

--- a/spec/cloud_payments/namespaces/orders_spec.rb
+++ b/spec/cloud_payments/namespaces/orders_spec.rb
@@ -42,4 +42,16 @@ describe CloudPayments::Namespaces::Orders do
       end
     end
   end
+
+  describe '#cancel' do
+    context do
+      before{ stub_api_request('orders/cancel/successful').perform }
+      specify{ expect(subject.cancel('12345')).to be_truthy }
+    end
+
+    context do
+      before{ stub_api_request('orders/cancel/failed').perform }
+      specify{ expect{ subject.cancel('12345') }.to raise_error(CloudPayments::Client::GatewayError, 'Error message') }
+    end
+  end
 end

--- a/spec/fixtures/apis/orders/cancel/failed.yml
+++ b/spec/fixtures/apis/orders/cancel/failed.yml
@@ -1,0 +1,6 @@
+---
+:request:
+  :url: '/orders/cancel'
+  :body: '{"Id":"12345"}'
+:response:
+  :body: '{"Success":false,"Message":"Error message"}'

--- a/spec/fixtures/apis/orders/cancel/successful.yml
+++ b/spec/fixtures/apis/orders/cancel/successful.yml
@@ -1,0 +1,6 @@
+---
+:request:
+  :url: '/orders/cancel'
+  :body: '{"Id":"12345"}'
+:response:
+  :body: '{"Success":true,"Message":null}'


### PR DESCRIPTION
https://cloudpayments.ru/Docs/Api#cancelOrder

```ruby
CloudPayments.client.orders.cancel(id)
```

*Hint*
If this PR will not be merged in, just do:
```ruby
CloudPayments.client.orders.request(:cancel, id: id)
```