### PR TITLE
Handle `Refunded` attribute in transaction model

### DIFF
--- a/lib/cloud_payments/models/transaction.rb
+++ b/lib/cloud_payments/models/transaction.rb
@@ -42,6 +42,7 @@ module CloudPayments
     property :status_code
     property :reason
     property :reason_code
+    property :refunded
     property :card_holder_message
     property :token
 
@@ -79,6 +80,10 @@ module CloudPayments
 
     def declined?
       status == DECLINED
+    end
+
+    def refunded?
+      refunded
     end
   end
 end

--- a/spec/cloud_payments/models/transaction_spec.rb
+++ b/spec/cloud_payments/models/transaction_spec.rb
@@ -40,6 +40,7 @@ describe CloudPayments::Transaction do
       status_code: 3,
       reason: 'Approved',
       reason_code: 0,
+      refunded: false,
       card_holder_message: 'Payment successful',
       name: 'CARDHOLDER NAME',
       token: 'a4e67841-abb0-42de-a364-d1d8f9f4b3c0'
@@ -80,6 +81,7 @@ describe CloudPayments::Transaction do
     specify{ expect(subject.card_holder_message).to eq('Payment successful') }
     specify{ expect(subject.name).to eq('CARDHOLDER NAME') }
     specify{ expect(subject.token).to eq('a4e67841-abb0-42de-a364-d1d8f9f4b3c0') }
+    specify{ expect(subject.refunded).to eq(false) }
 
     context 'without any attributes' do
       let(:attributes){ {} }
@@ -117,6 +119,7 @@ describe CloudPayments::Transaction do
     it_behaves_like :not_raise_without_attribute, :issuer_bank_country
     it_behaves_like :not_raise_without_attribute, :reason
     it_behaves_like :not_raise_without_attribute, :reason_code
+    it_behaves_like :not_raise_without_attribute, :refunded
     it_behaves_like :not_raise_without_attribute, :card_holder_message
     it_behaves_like :not_raise_without_attribute, :name
     it_behaves_like :not_raise_without_attribute, :token
@@ -252,6 +255,23 @@ describe CloudPayments::Transaction do
       context do
         let(:attributes){ { ip_longitude: 12.34 } }
         specify{ expect(subject.ip_location).to be_nil }
+      end
+    end
+
+    describe '#refunded?' do
+      context do
+        let(:attributes) { { refunded: false } }
+        specify { expect(subject.refunded?).to be_falsey }
+      end
+
+      context do
+        let(:attributes) { { refunded: true } }
+        specify { expect(subject.refunded?).to be_truthy }
+      end
+
+      context do
+        let(:attributes) { { refunded: nil } }
+        specify { expect(subject.refunded?).to be_falsey }
       end
     end
   end

--- a/spec/cloud_payments/namespaces/payments_spec.rb
+++ b/spec/cloud_payments/namespaces/payments_spec.rb
@@ -123,6 +123,12 @@ describe CloudPayments::Namespaces::Payments do
         specify{ expect(subject.get(transaction_id).id).to eq(transaction_id) }
         specify{ expect(subject.get(transaction_id).reason).to eq('Approved') }
       end
+
+      context 'transaction is refunded' do
+        before{ stub_api_request('payments/get/refunded').perform }
+        specify{ expect(subject.get(transaction_id)).to be_completed }
+        specify{ expect(subject.get(transaction_id)).to be_refunded }
+      end
     end
 
     context 'config.raise_banking_errors = true' do

--- a/spec/fixtures/apis/payments/get/failed.yml
+++ b/spec/fixtures/apis/payments/get/failed.yml
@@ -37,6 +37,7 @@
         "StatusCode": 5,
         "Reason": "InsufficientFunds",
         "ReasonCode": 5051,
+        "Refunded": false,
         "CardHolderMessage": "Insufficient funds on account",
         "Name": "CARDHOLDER NAME"
       },

--- a/spec/fixtures/apis/payments/get/refunded.yml
+++ b/spec/fixtures/apis/payments/get/refunded.yml
@@ -39,7 +39,7 @@
         "StatusCode":3,
         "Reason":"Approved",
         "ReasonCode":0,
-        "Refunded": false,
+        "Refunded": true,
         "CardHolderMessage":"Payment successful",
         "Name":"CARDHOLDER NAME",
         "Token":"a4e67841-abb0-42de-a364-d1d8f9f4b3c0"


### PR DESCRIPTION
Transaction has a "Refunded" attribute.
It's false by default and true when transaction is (surprise) refunded.

This commit adds `refunded` property and `refunded?` method to Transaction model.